### PR TITLE
feat: add `generate-token` and enable static type checking with pyright

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{py,ini}]
+indent_style = space
+indent_size = 4
+
+[*.{yaml,yml,tf}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 .idea
 .vscode/
 cover
+.charmhub.secret

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,6 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10
+
+[tool.pyright]
+include = ["src/**.py"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023-2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = fmt, lint, unit
+envlist = fmt, lint, typecheck, unit
 
 [vars]
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
-all_path = {[vars]src_path} {[vars]tst_path} 
+all_path = {[vars]src_path} {[vars]tst_path}
 
 [testenv]
 setenv =
@@ -45,7 +45,7 @@ commands =
         --skip {toxinidir}/venv \
         --skip {toxinidir}/.mypy_cache \
         --skip {toxinidir}/icon.svg
-    
+
     ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
@@ -67,6 +67,14 @@ commands =
     coverage report
     coverage xml -o cover/coverage.xml
 
+[testenv:typecheck]
+description = Run static type checks
+deps =
+    pyright
+    -r {tox_root}/requirements.txt
+commands =
+    pyright {posargs}
+
 [testenv:integration]
 description = Run integration tests
 deps =
@@ -79,3 +87,17 @@ commands =
         --ignore={[vars]tst_path}unit \
         --log-cli-level=INFO \
         {posargs}
+
+[testenv:generate-token]
+description =
+allowlist_externals =
+    /snap/bin/charmcraft
+commands =
+    charmcraft login --export .charmhub.secret \
+        --permission=package-manage-metadata \
+        --permission=package-manage-releases \
+        --permission=package-manage-revisions \
+        --permission=package-view-metadata \
+        --permission=package-view-releases \
+        --permission=package-view-revisions \
+        --ttl=777600


### PR DESCRIPTION
This PR adds the `generate-token` tox env to make it easy to quickly generate Charmhub access tokens. This PR also enables static type checking with `pyright` which brings this repo in line with our other projects:

```shell
tox run -e typecheck
```

### Misc.

Also adds a _.editorconfig_ file to ensure that editor setting are consistent across text editors/IDEs.